### PR TITLE
Spell-test scripts in bin/

### DIFF
--- a/corpus/foo/bin/foo
+++ b/corpus/foo/bin/foo
@@ -6,4 +6,6 @@ print "foo\n";
 
 Prints "foo".
 
+bigfatspellingerrorajoidufhlsidufmahiefmhregrge
+
 =cut

--- a/corpus/foo/bin/foo
+++ b/corpus/foo/bin/foo
@@ -1,0 +1,9 @@
+#!perl
+
+print "foo\n";
+
+=head1 Foo
+
+Prints "foo".
+
+=cut

--- a/corpus/foo/dist.ini
+++ b/corpus/foo/dist.ini
@@ -1,0 +1,7 @@
+name = Foo
+license = Perl_5
+copyright_holder = Fooer
+version = 1
+
+[GatherDir]
+[Test::PodSpelling]

--- a/corpus/foo/lib/Foo.pm
+++ b/corpus/foo/lib/Foo.pm
@@ -1,0 +1,9 @@
+package Foo;
+# ABSTRACT: test dzil pod spell check
+1;
+
+=head1 Foo
+
+Spell check
+
+=cut

--- a/corpus/nobin/dist.ini
+++ b/corpus/nobin/dist.ini
@@ -1,0 +1,7 @@
+name = Foo
+license = Perl_5
+copyright_holder = Fooer
+version = 1
+
+[GatherDir]
+[Test::PodSpelling]

--- a/corpus/nobin/lib/Foo.pm
+++ b/corpus/nobin/lib/Foo.pm
@@ -1,0 +1,9 @@
+package Foo;
+# ABSTRACT: test dzil pod spell check
+1;
+
+=head1 Foo
+
+Spell check
+
+=cut

--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ Pod::Wordlist::hanekomu = 0
 [PodWeaver]
 
 [MetaNoIndex]
+	directory = corpus
 	file = perlcritic.rc
 
 [MetaJSON]

--- a/lib/Dist/Zilla/Plugin/Test/PodSpelling.pm
+++ b/lib/Dist/Zilla/Plugin/Test/PodSpelling.pm
@@ -160,6 +160,6 @@ plan skip_all => "Test::Spelling 0.12 required for testing POD spelling"
 
 {{ $set_spell_cmd }}
 {{ $add_stopwords }}
-all_pod_files_spelling_ok('lib');
+all_pod_files_spelling_ok('bin', 'lib');
 {{ $stopwords }}
 

--- a/t/checked.t
+++ b/t/checked.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::Tester;
+use Test::More 0.88;
+use Test::Spelling;
+
+use Dist::Zilla::Tester;
+use Path::Class;
+use Cwd ();
+
+# lib/ and bin/
+spell_check_dist( foo   => file(qw(bin foo)), file(qw(lib Foo.pm)) );
+# just lib/
+spell_check_dist( nobin => file(qw(lib Foo.pm)) );
+
+done_testing;
+
+sub spell_check_dist {
+  my ($dir, @files) = @_;
+  my $tzil = Dist::Zilla::Tester->from_config({
+    dist_root => dir('corpus', $dir),
+  }, {
+    tempdir_root => '.build', # avoid creating ./tmp
+  });
+  $tzil->build;
+
+  my $cwd = Cwd::cwd;
+  # tests typically run from the build dir
+  chdir $tzil->tempdir->subdir('build') or die "chdir failed: $!";
+
+  check_tests(
+    sub {
+      # all_pod_files_spelling_ok sets a plan which causes problems
+      local *Test::Tester::Delegate::plan = sub {};
+
+      # run the actual xt file
+      do "${\ file(qw(xt author pod-spell.t)) }";
+    },
+    [
+      map {
+        +{
+          ok => 1,
+          name => 'POD spelling for ' . $_,
+          # depth: starts at 1; +1 for do-file; +1 for the all_ func
+          depth => 3,
+        },
+      }
+        @files
+    ],
+    "spell check pod for $dir"
+  );
+
+  # change back
+  chdir $cwd or die "chdir failed: $!";
+}

--- a/t/checked.t
+++ b/t/checked.t
@@ -9,12 +9,13 @@ use Path::Class;
 use Cwd ();
 
 # lib/ and bin/
-spell_check_dist( foo   => file(qw(bin foo)), file(qw(lib Foo.pm)) );
+spell_check_dist( foo   => [file(qw(bin foo)) => {ok => 0}], file(qw(lib Foo.pm)) );
 # just lib/
 spell_check_dist( nobin => file(qw(lib Foo.pm)) );
 
 done_testing;
 
+# @files should be a file (name) or an array ref of [file, hash-to-override-expected-results]
 sub spell_check_dist {
   my ($dir, @files) = @_;
   my $tzil = Dist::Zilla::Tester->from_config({
@@ -40,11 +41,13 @@ sub spell_check_dist {
       map {
         +{
           ok => 1,
-          name => 'POD spelling for ' . $_,
+          name => 'POD spelling for ' . $_->[0],
           # depth: starts at 1; +1 for do-file; +1 for the all_ func
           depth => 3,
+          %{ $_->[1] },
         },
       }
+      map { ref $_ eq 'ARRAY' ? $_ : [$_ => {}] }
         @files
     ],
     "spell check pod for $dir"


### PR DESCRIPTION
my script had all the same errors as the module but i didn't notice...
i didn't realize it wasn't being tested ;-)

Specifying "bin" in the test doesn't seem to cause any problems if the directory doesn't exist.

If it becomes an issue in the future it could obviously be made configurable...
could even do something fancy like using `$zilla->plugin_named('ExecDir')->dir` I suppose.
