### PR TITLE
Skip test if there is no working spell checker

### DIFF
--- a/t/checked.t
+++ b/t/checked.t
@@ -8,6 +8,9 @@ use Dist::Zilla::Tester;
 use Path::Class;
 use Cwd ();
 
+plan skip_all => 'No working spellchecker found'
+  unless Test::Spelling::has_working_spellchecker();
+
 # lib/ and bin/
 spell_check_dist( foo   => [file(qw(bin foo)) => {ok => 0}], file(qw(lib Foo.pm)) );
 # just lib/


### PR DESCRIPTION
Test::Spelling does this under the hood
which causes confusing behavior when Test::Tester doesn't know.

This fixes test failures like this one:
http://www.cpantesters.org/cpan/report/4a36b5f8-ffee-11e0-a9af-445633b12857
