### PR TITLE
Bump Test::Spelling prereq to 0.17 for windows fix

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,7 +8,7 @@ copyright_holder = Caleb Cushing
 
 [Bootstrap::lib]
 [Prereqs]
-Test::Spelling = 0
+Test::Spelling = 0.17
 Pod::Wordlist::hanekomu = 0
 
 [ReadmeFromPod]


### PR DESCRIPTION
closes gh-7.

Not sure if this is the branch you want, but you can cherry pick it or whatever
