### PR TITLE
Restrict perlcritic theme to core

### DIFF
--- a/perlcritic.rc
+++ b/perlcritic.rc
@@ -1,2 +1,3 @@
+theme = core
 severity = 3
 verbose  = 9


### PR DESCRIPTION
to avoid pulling in random (undesired) themes that may be installed.

Without it I get this output on my machine:

```
t/author-critic.t ............ 2/2 
#   Failed test 'Test::Perl::Critic for "blib/lib/Dist/Zilla/Plugin/Test/PodSpelling.pm"'
#   at /home/rando/perl5/perlbrew/perls/5.14.2-st/lib/site_perl/5.14.2/Test/Perl/Critic.pm line 110.
# 
# Perl::Critic found these violations in "blib/lib/Dist/Zilla/Plugin/Test/PodSpelling.pm":
# [Bangs::ProhibitVagueNames] Variable named "$data" at line 55, near '$self, $data'.  (Severity: 3)
# [Bangs::ProhibitVagueNames] Variable named "$data" at line 57, near ''attempting stopwords extraction from: ' . $data'.  (Severity: 3)
# [Bangs::ProhibitVagueNames] Variable named "$data" at line 59, near 'my ( $word ) = $data =~ /(\p{Word}{2,})/xms;'.  (Severity: 3)
# Looks like you failed 1 test of 2.
t/author-critic.t ............ Dubious, test returned 1 (wstat 256, 0x100)
```
