### PR TITLE
delay calling distmeta until filemunging phase

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+        - prevent distmeta from being populated too early by postponing
+          calling it until the file munging phase
 
 2.006002  2013-12-19
 	- fix problem with compile tests stalling on windows (chorny) GH #20

--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ Test::Spelling          = 0.12
 [@Filter]
 	-bundle = @Basic
 	-remove = Readme
+	-remove = ExtraTests
 
 [AutoPrereqs]
 
@@ -52,6 +53,8 @@ Test::Spelling          = 0.12
 [PruneFiles]
 	filenames = dist.ini
 	filenames = weaver.ini
+
+[ExtraTests]
 
 [Git::Remote::Check]
 [ContributorsFromGit]

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More 0.88;
 use Test::DZil;
+use Path::Tiny;
 
 # test the file content generated when various attributes are set
 
@@ -17,6 +18,7 @@ sub get_content {
     { dist_root => 'corpus/foo' },
     {
       add_files => {
+        'source/lib/Spell/Checked.pm' => "package Spell::Checked;\n1;\n",
         'source/dist.ini' => dist_ini(
           {
             name             => 'Spell-Checked',
@@ -26,15 +28,17 @@ sub get_content {
             author           => $author,
             copyright_holder => $author,
           },
+          [GatherDir =>],
           [$name => $args],
         )
       }
     }
   );
 
-  my $plugin = $zilla->plugin_named($name);
-  $plugin->gather_files;
-  return $zilla->files->[0]->content;
+  $zilla->build;
+  my $build_dir = $zilla->tempdir->subdir('build');
+  my $file = path($build_dir, 'xt', 'author', 'pod-spell.t');
+  return $file->slurp_utf8;
 }
 
 my $content = get_content({});

--- a/t/contributors.t
+++ b/t/contributors.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More 0.88;
 use Test::Requires 'Dist::Zilla::Plugin::Meta::Contributors';
 use Test::DZil;
+use Path::Tiny;
 
 # test the file content generated gets contributor
 
@@ -20,6 +21,7 @@ sub get_content {
     { dist_root => 'corpus/foo' },
     {
       add_files => {
+        'source/lib/Spell/Checked.pm' => "package Spell::Checked;\n1;\n",
         'source/dist.ini' => dist_ini(
           {
             name => 'Spell-Checked',
@@ -29,6 +31,7 @@ sub get_content {
             author => 'John Doe <jdoe@example.com>',
             copyright_holder => 'John Doe <jdoe@example.com>'
           },
+          [GatherDir =>],
           [$name => $args],
           ['Meta::Contributors',
               {
@@ -40,9 +43,10 @@ sub get_content {
     }
   );
 
-  my $plugin = $zilla->plugin_named($name);
-  $plugin->gather_files;
-  return $zilla->files->[0]->content;
+  $zilla->build;
+  my $build_dir = $zilla->tempdir->subdir('build');
+  my $file = path($build_dir, 'xt', 'author', 'pod-spell.t');
+  return $file->slurp_utf8;
 }
 
 my $content = get_content({});

--- a/t/dashed.t
+++ b/t/dashed.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More 0.88;
 use Test::DZil;
+use Path::Tiny;
 
 # test the file content generated when various attributes are set
 
@@ -20,6 +21,7 @@ sub get_content {
     { dist_root => 'corpus/foo' },
     {
       add_files => {
+        'source/lib/Spell/Checked.pm' => "package Spell::Checked;\n1;\n",
         'source/dist.ini' => dist_ini(
           {
             name => 'Spell-Checked',
@@ -29,15 +31,17 @@ sub get_content {
             author => $author,
             copyright_holder => $author,
           },
+          [GatherDir =>],
           [$name => $args],
         )
       }
     }
   );
 
-  my $plugin = $zilla->plugin_named($name);
-  $plugin->gather_files;
-  return $zilla->files->[0]->content;
+  $zilla->build;
+  my $build_dir = $zilla->tempdir->subdir('build');
+  my $file = path($build_dir, 'xt', 'author', 'pod-spell.t');
+  return $file->slurp_utf8;
 }
 
 my $content = get_content({});

--- a/t/file.t
+++ b/t/file.t
@@ -11,7 +11,11 @@ my $tzil
 		},
 		{
 			add_files => {
-				'source/dist.ini' => simple_ini(['Test::PodSpelling'])
+				'source/lib/Foo.pm' => "package Foo;\n1;\n",
+				'source/dist.ini' => simple_ini(
+					[ GatherDir => ],
+					['Test::PodSpelling']
+				)
 			}
 		},
 	);


### PR DESCRIPTION
In one distribution I was constructing, I needed to remove this plugin because it was forcing all plugins' MetaProvider phase to fire prematurely, before all files had even been added to the dist.  Delaying munging the template content until the filemunging phase fixes this -- the filegathering phase should just add static content.
