### PR TITLE
Topic/find moved file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+	- munge the file properly even if [ExtraTests] has already moved it
 
 2.006006  2014-02-27
 	- require Dist::Zilla 5

--- a/t/file.t
+++ b/t/file.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::DZil;
+use File::pushd 'pushd';
 use Test::Script 1.05;
 
 my $tzil
@@ -14,6 +15,7 @@ my $tzil
 				'source/lib/Foo.pm' => "package Foo;\n1;\n",
 				'source/dist.ini' => simple_ini(
 					[ GatherDir => ],
+					[ MakeMaker => ],
 					['Test::PodSpelling']
 				)
 			}
@@ -33,6 +35,11 @@ my $fn
 
 ok ( -e $fn, 'test file exists');
 
-script_compiles( '' . $fn->relative, 'check test compiles' );
+{
+	my $wd = pushd $tzil->tempdir->subdir('build');
+	$tzil->plugin_named('MakeMaker')->build;
+
+	script_compiles( '' . $fn->relative, 'check test compiles' );
+}
 
 done_testing;

--- a/t/phase.t
+++ b/t/phase.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use Test::Fatal;
+
+{
+	package Dist::Zilla::Plugin::CheckPhases;
+	use Moose;
+	with 'Dist::Zilla::Role::FileMunger';
+	use Moose::Util 'find_meta';
+
+	# runs before [Test::PodSpelling]'s munge_files
+	sub munge_files
+	{
+		my $self = shift;
+		my $distmeta_attr = find_meta($self->zilla)->find_attribute_by_name('distmeta');
+		die 'distmeta has already been calculated before file munging phase!'
+			if $distmeta_attr->has_value($self->zilla);
+	}
+}
+
+my $tzil
+	= Builder->from_config(
+		{
+			dist_root    => 'corpus/a',
+		},
+		{
+			add_files => {
+				'source/lib/Foo.pm' => "package Foo;\n1;\n",
+				'source/dist.ini' => simple_ini(
+					[ GatherDir => ],
+					[ CheckPhases => ],
+					['Test::PodSpelling']
+				)
+			}
+		},
+	);
+
+is(
+	exception { $tzil->build },
+	undef,
+	'no exceptions during dzil build',
+);
+
+done_testing;

--- a/t/renamed.t
+++ b/t/renamed.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use File::pushd 'pushd';
+use Test::Script 1.05;
+
+my $tzil
+	= Builder->from_config(
+		{
+			dist_root    => 'corpus/a',
+		},
+		{
+			add_files => {
+				'source/lib/Foo.pm' => "package Foo;\n1;\n",
+				'source/dist.ini' => simple_ini(
+					[ GatherDir => ],
+					[ MakeMaker => ],
+					[ ExtraTests => ],
+					['Test::PodSpelling']
+				)
+			}
+		},
+	);
+
+$tzil->build;
+
+my $fn
+	= $tzil
+	->tempdir
+	->subdir('build')
+	->subdir('t')
+	->file('author-pod-spell.t')
+	;
+
+ok ( -e $fn, 'test file exists');
+
+{
+	my $wd = pushd $tzil->tempdir->subdir('build');
+	$tzil->plugin_named('MakeMaker')->build;
+
+	script_compiles( '' . $fn->relative, 'check test compiles' );
+}
+
+done_testing;


### PR DESCRIPTION
One solution to #22: save the file object as it is added, so it can be munged later, even if it is renamed

I also fixed the test that does not run except under "dzil test", and added a test to ensure the file does not get munged until filemunging time.
